### PR TITLE
sup

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -63,20 +63,15 @@ fn default_headers() -> header::Headers {
 
 fn build_proxy_request(request: &Request, to: Uri, opts: &EnvOptions) -> Request {
     let mut req = Request::new(Method::Get, to);
-    {
-        let h = copy_headers!(request, default_headers(), {
-            set [ header::UserAgent::new(opts.user_agent.clone()) ],
-            if_present [ header::AcceptEncoding ],
-            or_default [ header::Accept::image() ]
-        });
-        let req_headers = req.headers_mut();
-        *req_headers = h;
-    }
+    *req.headers_mut() = copy_headers!(request, default_headers(), {
+        set [ header::UserAgent::new(opts.user_agent.clone()) ],
+        if_present [ header::AcceptEncoding ],
+        or_default [ header::Accept::image() ]
+    });
     req
 }
 
 fn build_proxy_response(response: Response, options: &EnvOptions) -> Response {
-
     let headers = copy_headers!(response, default_headers(), {
         set [ ],
         if_present [


### PR DESCRIPTION
i was catching up on your changes and they look extremely dope.

here's two things I fucked with:

64a168a: we can collapse a block into a single `copy_headers!` call. i think it ends up being a little more clear since you're assigning directly. this is totally cosmetic.

ae2eca8: i didn't even think about the client request returning an error! I think we still want to stay inside the state machine though. returning that future bails out immediately.